### PR TITLE
Add Help category form

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/help.yml
+++ b/.github/DISCUSSION_TEMPLATE/help.yml
@@ -1,0 +1,19 @@
+body:
+- type: textarea
+  attributes:
+    label: Summary
+    description: What do you need help with?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional information
+    description: Any code snippets, error messages, or dependency details that may be related?
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: Example
+    description: A link to a minimal reproduction is helpful for collaborative debugging!
+  validations:
+    required: false


### PR DESCRIPTION
Testing the new [category forms](https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms) feature. This adds prompts for a problem summary, additional details, and a repro link.