### PR TITLE
Create auto-close.yml

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -1,0 +1,28 @@
+name: Close Stale Discussions
+
+on:
+  workflow_dispatch:
+    inputs:
+      days-before-stale:
+        description: 'Number of days before a discussion is considered stale.'
+        default: '365'
+        required: true
+        type: string
+
+jobs:
+  close-stale-discussions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run action
+        id: autoclose
+        uses: steffen-karlsson/stalesweeper@v1.1.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message: "This discussion has been closed due to it's age."
+          days-before-close: ${{ inputs.days-before-stale }}
+          close-unanswered: true
+          close-reason: 'OUTDATED'
+      - name: Show Output
+        run: |
+          echo '${{ steps.autoclose.outputs.stale-discussions }}' | jq -r '"Closed \(length) stale discussions: "'
+          echo '${{ steps.autoclose.outputs.stale-discussions }}' | jq -r '"- https://github.com/amyegan/community-test/\(.[].number)"'


### PR DESCRIPTION
Adds an auto-close action for old discussions.

Initially configured for manual run due to large number of old discussions. After closing years-old discussions in batches, `days-before-close` can be changed to a more reasonable timeframe and the trigger can be changed to 
```yaml
  schedule:
    - cron: '0 0 * * *' # Run every day at midnight UTC
```